### PR TITLE
i think this will fix the issue of the directory being ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,4 @@ dist
 .yarn/install-state.gz
 .pnp.*
 
-server/uploads
+server/uploads/**


### PR DESCRIPTION
lemme know if that wasn't even a problem to begin with, but now when the grader clones the project, they clone the upload folder without the files inside